### PR TITLE
feat: reorganize nav bar, convert Services to dropdown with DevXRL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@
 ### Changed
 - Moved Ecosystem from standalone nav link into new Explore dropdown in HeaderNav
 - Added Explore dropdown with Ecosystem (internal route), devEco.io, and devEco.app (external links)
-- Nav order is now: Services | Explore (dropdown) | DevXRL | Community (dropdown) | Products | Contact Us
+- Reordered navigation: Services, Products, Community, Explore, Contact Us
+- Converted Services into dropdown containing Consultancy and DevXRL links
+- Moved DevXRL from standalone nav link into Services dropdown
 
 ### Fixed
 - *(none yet)*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ thedeveco.com/
 │   │   └── logo.svg          # Unused Vue default logo
 │   ├── components/
 │   │   ├── layout/
-│   │   │   ├── HeaderNav.vue # Sticky nav with mobile hamburger + Explore dropdown + Community dropdown
+│   │   │   ├── HeaderNav.vue # Sticky nav with mobile hamburger + Services dropdown + Community dropdown + Explore dropdown
 │   │   │   └── FooterNav.vue # 4-column footer with dynamic year
 │   │   ├── ui/
 │   │   │   ├── ClientLogos.vue        # Partner logo grid (manual entries, NOT auto-detected)
@@ -138,14 +138,16 @@ thedeveco.com/
 | Path | View Component | Load | Nav Label |
 |------|---------------|------|-----------|
 | `/` | HomeView.vue | Eager | (logo click) |
-| `/consultancy` | ConsultancyView.vue | Lazy | Services |
+| `/consultancy` | ConsultancyView.vue | Lazy | Services (dropdown trigger, clickable) |
 | `/ecosystem` | EcosystemView.vue | Lazy | Explore → Ecosystem (dropdown) |
-| `/devxrl` | DevXRL.vue | Lazy | DevXRL |
+| `/devxrl` | DevXRL.vue | Lazy | Services → DevXRL (dropdown) |
 | `/community` | CommunityView.vue | Lazy | Community (has dropdown) |
 | `/projects` | ProjectsView.vue | Lazy | Products |
 | `/contact` | ContactView.vue | Lazy | Contact Us (CTA button) |
 
-**Nav order**: Services | Explore (dropdown) | DevXRL | Community (dropdown) | Products | Contact Us (CTA)
+**Nav order**: Services (dropdown) | Products | Community (dropdown) | Explore (dropdown) | Contact Us (CTA)
+
+The Services nav item is a clickable `<router-link to="/consultancy">` with a hover dropdown containing: Consultancy (internal route), DevXRL (internal route).
 
 The Explore nav item includes a dropdown with: Ecosystem (internal route), devEco.io (external), devEco.app (external).
 

--- a/src/components/layout/HeaderNav.vue
+++ b/src/components/layout/HeaderNav.vue
@@ -38,7 +38,73 @@
       </button>
 
       <ul class="nav-links" :class="{ active: mobileMenuOpen }">
-        <li><router-link to="/consultancy" @click="closeNav">Services</router-link></li>
+        <li
+          class="nav-dropdown"
+          @mouseenter="openServicesDropdown"
+          @mouseleave="closeServicesDropdown"
+        >
+          <router-link to="/consultancy" @click="closeNav" class="nav-dropdown__trigger">
+            Services
+            <svg class="nav-dropdown__chevron" :class="{ open: servicesDropdownOpen }" width="10" height="6" viewBox="0 0 10 6" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M1 1l4 4 4-4" />
+            </svg>
+          </router-link>
+          <button class="nav-dropdown__mobile-toggle" @click="toggleMobileServicesDropdown">
+            <svg :class="{ open: mobileServicesDropdownOpen }" width="10" height="6" viewBox="0 0 10 6" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M1 1l4 4 4-4" />
+            </svg>
+          </button>
+          <Transition name="dropdown">
+            <ul v-show="servicesDropdownOpen" class="nav-dropdown__menu">
+              <li v-for="link in servicesLinks" :key="link.label">
+                <router-link :to="link.route" @click="closeNav">
+                  {{ link.label }}
+                </router-link>
+              </li>
+            </ul>
+          </Transition>
+          <ul v-show="mobileServicesDropdownOpen" class="nav-dropdown__mobile-menu">
+            <li v-for="link in servicesLinks" :key="link.label">
+              <router-link :to="link.route" @click="closeNav">
+                {{ link.label }}
+              </router-link>
+            </li>
+          </ul>
+        </li>
+        <li><router-link to="/projects" @click="closeNav">Products</router-link></li>
+        <li
+          class="nav-dropdown"
+          @mouseenter="openDropdown"
+          @mouseleave="closeDropdown"
+        >
+          <router-link to="/community" @click="closeNav" class="nav-dropdown__trigger">
+            Community
+            <svg class="nav-dropdown__chevron" :class="{ open: dropdownOpen }" width="10" height="6" viewBox="0 0 10 6" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M1 1l4 4 4-4" />
+            </svg>
+          </router-link>
+          <button class="nav-dropdown__mobile-toggle" @click="toggleMobileDropdown">
+            <svg :class="{ open: mobileDropdownOpen }" width="10" height="6" viewBox="0 0 10 6" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M1 1l4 4 4-4" />
+            </svg>
+          </button>
+          <Transition name="dropdown">
+            <ul v-show="dropdownOpen" class="nav-dropdown__menu">
+              <li v-for="link in communityLinks" :key="link.label">
+                <a :href="link.url" target="_blank" rel="noopener noreferrer" @click="closeNav">
+                  {{ link.label }}
+                </a>
+              </li>
+            </ul>
+          </Transition>
+          <ul v-show="mobileDropdownOpen" class="nav-dropdown__mobile-menu">
+            <li v-for="link in communityLinks" :key="link.label">
+              <a :href="link.url" target="_blank" rel="noopener noreferrer" @click="closeNav">
+                {{ link.label }}
+              </a>
+            </li>
+          </ul>
+        </li>
         <li
           class="nav-dropdown"
           @mouseenter="openExploreDropdown"
@@ -78,41 +144,6 @@
             </li>
           </ul>
         </li>
-        <li><router-link to="/devxrl" @click="closeNav">DevXRL</router-link></li>
-        <li
-          class="nav-dropdown"
-          @mouseenter="openDropdown"
-          @mouseleave="closeDropdown"
-        >
-          <router-link to="/community" @click="closeNav" class="nav-dropdown__trigger">
-            Community
-            <svg class="nav-dropdown__chevron" :class="{ open: dropdownOpen }" width="10" height="6" viewBox="0 0 10 6" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M1 1l4 4 4-4" />
-            </svg>
-          </router-link>
-          <button class="nav-dropdown__mobile-toggle" @click="toggleMobileDropdown">
-            <svg :class="{ open: mobileDropdownOpen }" width="10" height="6" viewBox="0 0 10 6" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M1 1l4 4 4-4" />
-            </svg>
-          </button>
-          <Transition name="dropdown">
-            <ul v-show="dropdownOpen" class="nav-dropdown__menu">
-              <li v-for="link in communityLinks" :key="link.label">
-                <a :href="link.url" target="_blank" rel="noopener noreferrer" @click="closeNav">
-                  {{ link.label }}
-                </a>
-              </li>
-            </ul>
-          </Transition>
-          <ul v-show="mobileDropdownOpen" class="nav-dropdown__mobile-menu">
-            <li v-for="link in communityLinks" :key="link.label">
-              <a :href="link.url" target="_blank" rel="noopener noreferrer" @click="closeNav">
-                {{ link.label }}
-              </a>
-            </li>
-          </ul>
-        </li>
-        <li><router-link to="/projects" @click="closeNav">Products</router-link></li>
         <li class="nav-cta"><router-link to="/contact" class="btn btn-primary" @click="closeNav">Contact Us</router-link></li>
       </ul>
     </div>
@@ -123,12 +154,20 @@
 import { ref } from 'vue'
 
 const mobileMenuOpen = ref(false)
+const servicesDropdownOpen = ref(false)
+const mobileServicesDropdownOpen = ref(false)
 const dropdownOpen = ref(false)
 const mobileDropdownOpen = ref(false)
 const exploreDropdownOpen = ref(false)
 const mobileExploreDropdownOpen = ref(false)
+let servicesCloseTimer: ReturnType<typeof setTimeout> | null = null
 let closeTimer: ReturnType<typeof setTimeout> | null = null
 let exploreCloseTimer: ReturnType<typeof setTimeout> | null = null
+
+const servicesLinks = [
+  { label: 'Consultancy', route: '/consultancy' },
+  { label: 'DevXRL', route: '/devxrl' },
+]
 
 const exploreLinks: { label: string; route?: string; url?: string }[] = [
   { label: 'Ecosystem', route: '/ecosystem' },
@@ -144,6 +183,24 @@ const communityLinks = [
   { label: 'Instagram', url: 'https://www.instagram.com/thedev.eco' },
   { label: 'Twitch', url: 'https://www.twitch.tv/thedeveco' },
 ]
+
+const openServicesDropdown = () => {
+  if (servicesCloseTimer) {
+    clearTimeout(servicesCloseTimer)
+    servicesCloseTimer = null
+  }
+  servicesDropdownOpen.value = true
+}
+
+const closeServicesDropdown = () => {
+  servicesCloseTimer = setTimeout(() => {
+    servicesDropdownOpen.value = false
+  }, 150)
+}
+
+const toggleMobileServicesDropdown = () => {
+  mobileServicesDropdownOpen.value = !mobileServicesDropdownOpen.value
+}
 
 const openExploreDropdown = () => {
   if (exploreCloseTimer) {
@@ -184,6 +241,7 @@ const toggleMobileDropdown = () => {
 const toggleNav = () => {
   mobileMenuOpen.value = !mobileMenuOpen.value
   if (!mobileMenuOpen.value) {
+    mobileServicesDropdownOpen.value = false
     mobileDropdownOpen.value = false
     mobileExploreDropdownOpen.value = false
   }
@@ -191,8 +249,10 @@ const toggleNav = () => {
 
 const closeNav = () => {
   mobileMenuOpen.value = false
+  mobileServicesDropdownOpen.value = false
   mobileDropdownOpen.value = false
   mobileExploreDropdownOpen.value = false
+  servicesDropdownOpen.value = false
   dropdownOpen.value = false
   exploreDropdownOpen.value = false
 }


### PR DESCRIPTION
Reorder nav: Services | Products | Community | Explore | Contact Us. Services is now a clickable router-link dropdown (like Community) containing Consultancy and DevXRL. DevXRL removed as standalone nav item.