### PR TITLE
feat: rename Products to About, reorder nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 - Reordered navigation: Services, Products, Community, Explore, Contact Us
 - Converted Services into dropdown containing Consultancy and DevXRL links
 - Moved DevXRL from standalone nav link into Services dropdown
+- Renamed Products nav tab to About and changed route from /projects to /about
+- Reordered navigation: About, Services, Community, Explore, Contact Us
 
 ### Fixed
 - *(none yet)*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ thedeveco.com/
 │   │   ├── WelcomeItem.vue   # Vue scaffolding (unused)
 │   │   └── icons/            # Vue scaffolding icon components (unused)
 │   ├── router/
-│   │   └── index.ts          # 7 routes: / /consultancy /ecosystem /devxrl /community /projects /contact
+│   │   └── index.ts          # 7 routes: / /consultancy /ecosystem /devxrl /community /about /contact
 │   ├── stores/
 │   │   └── counter.ts        # Pinia boilerplate (unused)
 │   └── views/
@@ -142,10 +142,10 @@ thedeveco.com/
 | `/ecosystem` | EcosystemView.vue | Lazy | Explore → Ecosystem (dropdown) |
 | `/devxrl` | DevXRL.vue | Lazy | Services → DevXRL (dropdown) |
 | `/community` | CommunityView.vue | Lazy | Community (has dropdown) |
-| `/projects` | ProjectsView.vue | Lazy | Products |
+| `/about` | ProjectsView.vue | Lazy | About |
 | `/contact` | ContactView.vue | Lazy | Contact Us (CTA button) |
 
-**Nav order**: Services (dropdown) | Products | Community (dropdown) | Explore (dropdown) | Contact Us (CTA)
+**Nav order**: About | Services (dropdown) | Community (dropdown) | Explore (dropdown) | Contact Us (CTA)
 
 The Services nav item is a clickable `<router-link to="/consultancy">` with a hover dropdown containing: Consultancy (internal route), DevXRL (internal route).
 
@@ -371,7 +371,7 @@ npm run lint         # ESLint with auto-fix
 - **Events**: 4-card grid
 - **CTA**: Navy background
 
-### ProjectsView (/projects)
+### ProjectsView (/about)
 - **Hero**: Navy with rocket-through-portal SVG animation (6s loop with gear emergence)
 - **Featured product**: portalNetwork in wide card layout with stats
 - **Products grid**: B3VY and LaunchCue in 2-column grid

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ public/
 | Ecosystem | `/ecosystem` | Directory of partners, clients, supported creators, collaborators |
 | DevXRL | `/devxrl` | DevXRL Audit product page with interactive readiness scale |
 | Community | `/community` | Community values, events, Discord CTA |
-| Products | `/projects` | portalNetwork, B3VY Live Hub, LaunchCue CRM |
+| About | `/about` | portalNetwork, B3VY Live Hub, LaunchCue CRM |
 | Contact | `/contact` | Contact options, form, virtual office hours |
 
 ## Design System

--- a/src/components/layout/FooterNav.vue
+++ b/src/components/layout/FooterNav.vue
@@ -19,11 +19,11 @@
         </div>
 
         <div class="footer-col">
-          <h4>Products</h4>
+          <h4>About</h4>
           <ul>
-            <li><router-link to="/projects">portalNetwork</router-link></li>
-            <li><router-link to="/projects">B3VY Live Hub</router-link></li>
-            <li><router-link to="/projects">LaunchCue CRM</router-link></li>
+            <li><router-link to="/about">portalNetwork</router-link></li>
+            <li><router-link to="/about">B3VY Live Hub</router-link></li>
+            <li><router-link to="/about">LaunchCue CRM</router-link></li>
           </ul>
         </div>
 

--- a/src/components/layout/HeaderNav.vue
+++ b/src/components/layout/HeaderNav.vue
@@ -38,6 +38,7 @@
       </button>
 
       <ul class="nav-links" :class="{ active: mobileMenuOpen }">
+        <li><router-link to="/about" @click="closeNav">About</router-link></li>
         <li
           class="nav-dropdown"
           @mouseenter="openServicesDropdown"
@@ -71,7 +72,6 @@
             </li>
           </ul>
         </li>
-        <li><router-link to="/projects" @click="closeNav">Products</router-link></li>
         <li
           class="nav-dropdown"
           @mouseenter="openDropdown"

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -30,8 +30,8 @@ const router = createRouter({
       component: () => import('../views/CommunityView.vue'),
     },
     {
-      path: '/projects',
-      name: 'projects',
+      path: '/about',
+      name: 'about',
       component: () => import('../views/ProjectsView.vue'),
     },
     {

--- a/src/views/CommunityView.vue
+++ b/src/views/CommunityView.vue
@@ -37,7 +37,7 @@
           </p>
           <div class="hero-cta">
             <a href="https://discord.gg/deveco" target="_blank" class="btn btn-primary">Join Discord</a>
-            <router-link to="/projects" class="btn btn-secondary">View Products</router-link>
+            <router-link to="/about" class="btn btn-secondary">View Products</router-link>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Route changed from /projects to /about. Nav order is now: About | Services | Community | Explore | Contact Us. All internal links updated site-wide (footer, community CTA).