### PR TITLE
chore(repo): update references after org migration to devEcoConsultingLLC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@
 - TRL section now includes a row of three summary badges (TRL, DevXRL, G2MRL).
 
 ### Changed
+- Repository transferred from `github.com/thedeveco/thedeveco.com` to `github.com/devEcoConsultingLLC/thedeveco.com`. GitHub permanent redirect handles legacy URLs.
+- Updated the GitHub link in the Community dropdown (HeaderNav.vue) and Community footer column (FooterNav.vue) from `github.com/thedeveco` to `github.com/devEcoConsultingLLC`.
+- Updated the repository URL in `CLAUDE.md` Project Identity section.
+- Updated the `git clone` command in `README.md` to reference the new org.
+- Added `rel="noopener noreferrer"` to the Community GitHub link in `FooterNav.vue` for security consistency with other external links in the footer.
 - Renamed `/about` route to `/team`. `ProjectsView.vue` renamed to `TeamView.vue`. Page content unchanged.
 - FooterNav grid changed from 4 columns to 5 columns (Brand, About, Audits, Community, Explore) with tightened gap from `--space-xl` to `--space-lg` to fit the additional column cleanly.
 - Nav top-level order is now: About -> Audits -> Community -> Explore -> Contact Us.
@@ -74,6 +79,12 @@
 - Removed Partners & Clients static grid section from home page
 - Deleted `ClientLogos.vue` component (replaced by `LogoCarousel`)
 - Removed static CTA section from /about page (replaced by Community Engine widget)
+
+### Infrastructure
+- DNS at Namecheap: `www` CNAME updated to `devecoconsultingllc.github.io`.
+- DNS at Namecheap: `consult` subdomain migrated from a CNAME (pointing at old org) to a Permanent (301) URL Redirect Record forwarding to `https://thedeveco.com/consultancy`. The `consult` subdomain is functionally deprecated.
+- GitHub Pages: HTTPS enforcement enabled on the new repo.
+- Claude Code GitHub App reinstalled on the `devEcoConsultingLLC` org.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 
 ## Project Identity
 
-**Repository**: `github.com/thedeveco/thedeveco.com`
+**Repository**: `github.com/devEcoConsultingLLC/thedeveco.com`
 **Live URL**: `https://thedeveco.com`
 **Owner**: devEco Consulting LLC (Robert Wolff, Founder)
 **Purpose**: Professional website for devEco Consulting — a developer relations consultancy and community platform
@@ -344,6 +344,7 @@ npm run lint         # ESLint with auto-fix
 6. **DevXRL page overrides global styles** — Has its own complete reset and design system within `.devxrl` scope; adds `devxrl-page` class to `<html>` for scroll-snap
 7. **Some animation styles are unscoped** — HomeView, CommunityView, ConsultancyView, and TeamView use unscoped `<style>` blocks for SVG animations. Be careful not to create class name collisions
 8. **CommunityView has a mislabeled button** — A "View Products" button on /community routes to /team. The destination is correct after the nav restructure, but the label is stale and should be updated to something like "Meet the Team" in a follow-up.
+9. **Org migration note**: In April 2026, the repository was transferred from `thedeveco` (legacy org) to `devEcoConsultingLLC` (current org, public repo). GitHub's permanent redirect means old links to `github.com/thedeveco/thedeveco.com` continue to work. The `thedeveco` org may or may not still exist depending on subsequent decisions, but the canonical home for this codebase is `devEcoConsultingLLC`. The repo is currently public; there is an open consideration to flip it to private later, which would require the org to be on GitHub Team plan or higher.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Professional website for **devEco Consulting LLC**, a developer relations consul
 
 ```bash
 # Prerequisites: Node.js 20+ or 22+
-git clone https://github.com/thedeveco/thedeveco.com.git
+git clone https://github.com/devEcoConsultingLLC/thedeveco.com.git
 cd thedeveco.com
 npm install
 npm run dev

--- a/src/components/layout/FooterNav.vue
+++ b/src/components/layout/FooterNav.vue
@@ -30,7 +30,7 @@
           <h4>Community</h4>
           <ul>
             <li><a href="https://discord.gg/deveco" target="_blank">Discord</a></li>
-            <li><a href="https://github.com/thedeveco" target="_blank">GitHub</a></li>
+            <li><a href="https://github.com/devEcoConsultingLLC" target="_blank" rel="noopener noreferrer">GitHub</a></li>
             <li><a href="https://www.linkedin.com/company/developerecosystem/" target="_blank">LinkedIn</a></li>
             <li><a href="https://www.youtube.com/@thedeveco" target="_blank">YouTube</a></li>
             <li><a href="https://www.instagram.com/thedev.eco" target="_blank">Instagram</a></li>

--- a/src/components/layout/HeaderNav.vue
+++ b/src/components/layout/HeaderNav.vue
@@ -273,7 +273,7 @@ const exploreLinks: { label: string; route?: string; url?: string }[] = [
 
 const communityLinks = [
   { label: 'Discord', url: 'https://discord.gg/deveco' },
-  { label: 'GitHub', url: 'https://github.com/thedeveco' },
+  { label: 'GitHub', url: 'https://github.com/devEcoConsultingLLC' },
   { label: 'LinkedIn', url: 'https://www.linkedin.com/company/developerecosystem/' },
   { label: 'YouTube', url: 'https://www.youtube.com/@thedeveco' },
   { label: 'Instagram', url: 'https://www.instagram.com/thedev.eco' },


### PR DESCRIPTION
## Summary

Post-org-migration repo cleanup. The repo transfer from `thedeveco` to `devEcoConsultingLLC` is already complete (GitHub Pages serving, DNS migrated, permanent redirect in place). This PR updates the four in-repo references that still point at the old org, plus bible file metadata.

## Changes

**Code references (old org to new org):**
- `CLAUDE.md` Project Identity: repo URL updated
- `README.md` Quick Start: `git clone` URL updated
- `src/components/layout/HeaderNav.vue`: Community dropdown GitHub link updated
- `src/components/layout/FooterNav.vue`: Community footer GitHub link updated, also gained `rel="noopener noreferrer"` for consistency with other external links in the footer

**Bible file updates:**
- `CLAUDE.md` Known Issues: added item 9 documenting the org migration, public-repo status, and the open "flip to private" consideration (requires GitHub Team plan)
- `CHANGELOG.md` `[Unreleased]`: five `### Changed` entries describing the code/doc updates, plus a new `### Infrastructure` subsection documenting DNS updates at Namecheap (`www` CNAME, `consult` subdomain 301 redirect), GitHub Pages HTTPS enforcement, and Claude Code GitHub App reinstall on the new org

## Non-changes

- `public/CNAME` untouched (still correctly `thedeveco.com`)
- `.github/workflows/deploy.yml` untouched (working under the new org)
- No page view files modified
- Domain references to `thedeveco.com` untouched (only org references changed)

## Test plan

- [x] `npm install` clean
- [x] `npm run type-check` passes
- [x] `npm run build` passes
- [x] `npx eslint` on `HeaderNav.vue` and `FooterNav.vue` passes
- [ ] Manual smoke: hover Community nav, click GitHub in dropdown, confirm it opens `https://github.com/devEcoConsultingLLC` in a new tab
- [ ] Manual smoke: footer Community column GitHub link opens `https://github.com/devEcoConsultingLLC` in a new tab