### PR TITLE
feat(privacy): add cookie consent notice and privacy page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 ## [Unreleased]
 
 ### Added
+- Added a global cookie consent notice (`src/components/ui/CookieConsent.vue`), mounted in `App.vue`, that appears on first visit and persists dismissal in localStorage under `deveco-cookie-consent`.
+- Added a `/privacy` route and `PrivacyView.vue` with an honest privacy and cookie statement reflecting the site's current no-tracking state.
+- Added a Privacy link to the footer bottom bar in `FooterNav.vue`.
 - Added six ecosystem listings in `src/views/EcosystemView.vue`: Open Sauce and Jumperless (We Support), BrainChip and NextPCB (We Serve), Avnet and Advantech (We Have Worked With).
 - New About dropdown in HeaderNav, non-clickable parent, containing Team (/team), Consultancy (/consultancy), and Ecosystem (/ecosystem).
 - New Audits dropdown in HeaderNav, non-clickable parent, containing DevXRL, SMRL, G2MRL, and TRL. All four audit links open in new tabs via `target="_blank"` anchors.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,8 +77,8 @@ thedeveco.com/
 │   │   └── tory.jpg
 │   └── trail-sandiego/       # Static export of EDGE AI Trail game (Next.js)
 ├── src/
-│   ├── App.vue               # Root component: HeaderNav + RouterView + FooterNav
-│   │                         # Contains ALL global CSS variables and base styles
+│   ├── App.vue               # Root component: HeaderNav + RouterView + FooterNav + CookieConsent
+│   │                         # Contains ALL global CSS variables and base styles; mounts the global CookieConsent banner
 │   ├── main.ts               # Entry point: Font Awesome setup, Pinia, Router, SPA redirect handler
 │   ├── assets/
 │   │   ├── base.css          # Vue scaffolding CSS (mostly overridden by App.vue)
@@ -92,13 +92,14 @@ thedeveco.com/
 │   │   │   ├── LogoCarousel.vue        # Auto-scrolling logo carousel (pause-on-hover, CSS animation)
 │   │   │   ├── EcosystemTile.vue      # Clickable tile card for ecosystem listings
 │   │   │   ├── EcosystemModal.vue     # Detail modal for ecosystem listings (Teleport to body)
+│   │   │   ├── CookieConsent.vue      # Fixed-bottom cookie consent notice (first-visit, localStorage)
 │   │   │   └── ProcessVisualization.vue # 4-step process with FA icons (unused on current pages)
 │   │   ├── HelloWorld.vue    # Vue scaffolding (unused)
 │   │   ├── TheWelcome.vue    # Vue scaffolding (unused)
 │   │   ├── WelcomeItem.vue   # Vue scaffolding (unused)
 │   │   └── icons/            # Vue scaffolding icon components (unused)
 │   ├── router/
-│   │   └── index.ts          # 12 routes: / /consultancy /ecosystem /devxrl /smrl /g2mrl /trl /community /team /about (redirect) /contact /heimdall
+│   │   └── index.ts          # 13 routes: / /consultancy /ecosystem /devxrl /smrl /g2mrl /trl /community /team /about (redirect) /contact /heimdall /privacy
 │   ├── stores/
 │   │   └── counter.ts        # Pinia boilerplate (unused)
 │   └── views/
@@ -113,6 +114,7 @@ thedeveco.com/
 │       ├── TeamView.vue       # Team/About page with rocket-portal SVG animation and Community Engine widget
 │       ├── ContactView.vue    # Contact form (simulated submission, no backend)
 │       ├── HeimdallView.vue   # Hidden easter egg page (not in nav)
+│       ├── PrivacyView.vue    # Privacy and cookies statement (linked from footer)
 │       └── AboutView.vue      # Boilerplate placeholder (not in router)
 ├── index.html                # Vite entry HTML
 ├── package.json
@@ -150,6 +152,7 @@ thedeveco.com/
 | `/about` | (redirect) | — | (redirects to /team) |
 | `/contact` | ContactView.vue | Lazy | Contact Us (CTA button) |
 | `/heimdall` | HeimdallView.vue | Lazy | (hidden — easter egg, not in nav) |
+| `/privacy` | PrivacyView.vue | Lazy | Privacy (footer link) |
 
 **Nav order**: About (dropdown) | Audits (dropdown) | Community (dropdown) | Explore (dropdown) | Contact Us (CTA)
 
@@ -290,6 +293,9 @@ Ecosystem listings in `EcosystemView.vue` are defined as a TypeScript array of `
 - `shortDescription`, `tags?`, `longDescription?`, `website?`, `socialLinks?`, `highlights?`
 - Listings are grouped into sections by category and rendered as `EcosystemTile` + `EcosystemModal` pairs
 
+### Cookie Consent
+The global `CookieConsent` banner (`src/components/ui/CookieConsent.vue`, mounted in `App.vue`) persists acceptance in `localStorage` under the key `deveco-cookie-consent` (value `'accepted'`). All storage access is wrapped in try/catch. This is the only use of `localStorage` in the app.
+
 ---
 
 ## Git Workflow
@@ -421,6 +427,12 @@ npm run lint         # ESLint with auto-fix
 - **Form**: Name, email, company, service dropdown, message textarea (simulated submission)
 - **Office hours**: Navy section with schedule details
 
+### PrivacyView (/privacy)
+- **Hero**: Navy background, centered, with a Privacy stamp eyebrow
+- **Statement**: Single readable column (720px max-width) with section headings (Overview, Information We Collect, Cookies and Local Storage, Third-Party Services, Your Choices, Contact, Changes)
+- **Honest to the current no-tracking state**: No analytics, no tracking, essential session storage only; discloses Google Fonts and GitHub Pages
+- *Note*: Linked from the footer bottom bar; reached by the global `CookieConsent` banner
+
 ---
 
 ## Adding a New Page (Step-by-Step)
@@ -479,3 +491,4 @@ When ending a session that made changes:
 
 *Last updated: 2026-06-26*
 *Bible file version: 1.0*
+

--- a/README.md
+++ b/README.md
@@ -62,9 +62,10 @@ src/
 │       ├── LogoCarousel.vue    # Auto-scrolling partner/client logo carousel
 │       ├── EcosystemTile.vue  # Clickable card for ecosystem listings
 │       ├── EcosystemModal.vue # Detail modal for ecosystem listings
+│       ├── CookieConsent.vue  # Fixed-bottom cookie consent notice
 │       └── ProcessVisualization.vue
 ├── router/
-│   └── index.ts               # 12 routes
+│   └── index.ts               # 13 routes
 ├── stores/
 │   └── counter.ts             # Pinia boilerplate
 └── views/
@@ -79,6 +80,7 @@ src/
     ├── TeamView.vue            # Team/About page with rocket-portal animation
     ├── ContactView.vue         # Contact form and office hours
     ├── HeimdallView.vue        # Hidden easter egg page (not in nav)
+    ├── PrivacyView.vue         # Privacy and cookie statement (linked from footer)
     └── AboutView.vue           # Boilerplate placeholder (not in router)
 
 public/
@@ -106,6 +108,7 @@ public/
 | Community | `/community` | Community | Community values, events, Discord CTA |
 | Team | `/team` | About dropdown | The Collective team section, rocket-portal animation |
 | Contact | `/contact` | Contact Us CTA | Contact options, form, virtual office hours |
+| Privacy | `/privacy` | Footer link | Privacy and cookie statement (linked from footer) |
 
 `/about` redirects to `/team` to preserve backward compatibility with older links. A hidden `/heimdall` easter egg route exists but is not linked from the nav.
 
@@ -159,4 +162,4 @@ This project uses bible files for session-agnostic development:
 
 *devEco Consulting LLC — DevRel from the workshop floor.*
 
-*Last updated: 2026-06-25*
+*Last updated: 2026-06-26*

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,6 +2,7 @@
 import { RouterView } from 'vue-router'
 import HeaderNav from './components/layout/HeaderNav.vue'
 import FooterNav from './components/layout/FooterNav.vue'
+import CookieConsent from './components/ui/CookieConsent.vue'
 </script>
 
 <template>
@@ -11,6 +12,7 @@ import FooterNav from './components/layout/FooterNav.vue'
       <RouterView />
     </main>
     <FooterNav />
+    <CookieConsent />
   </div>
 </template>
 

--- a/src/components/layout/FooterNav.vue
+++ b/src/components/layout/FooterNav.vue
@@ -48,7 +48,7 @@
       </div>
 
       <div class="footer-bottom">
-        <span>{{ currentYear }} | devEco Consulting LLC</span>
+        <span>{{ currentYear }} | devEco Consulting LLC | <router-link to="/privacy">Privacy</router-link></span>
         <span>EDGE AI FOUNDATION | <a href="https://www.edgeaifoundation.org/" target="_blank">Scholarship Partner</a></span>
       </div>
     </div>

--- a/src/components/ui/CookieConsent.vue
+++ b/src/components/ui/CookieConsent.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+
+const STORAGE_KEY = 'deveco-cookie-consent'
+const visible = ref(false)
+
+onMounted(() => {
+  try {
+    if (localStorage.getItem(STORAGE_KEY) !== 'accepted') visible.value = true
+  } catch {
+    visible.value = true
+  }
+})
+
+function accept() {
+  try {
+    localStorage.setItem(STORAGE_KEY, 'accepted')
+  } catch {
+    // storage unavailable; dismiss for this session only
+  }
+  visible.value = false
+}
+</script>
+
+<template>
+  <Transition name="cookie-fade">
+    <div v-if="visible" class="cookie-banner" role="region" aria-label="Cookie notice">
+      <div class="cookie-inner">
+        <p class="cookie-message">
+          This site uses only essential cookies needed to function. It runs no advertising,
+          analytics, or tracking. Read our
+          <router-link to="/privacy" class="cookie-link">Privacy and Cookies</router-link>
+          statement for details.
+        </p>
+        <button class="btn btn-primary cookie-button" @click="accept">Got it</button>
+      </div>
+    </div>
+  </Transition>
+</template>
+
+<style scoped>
+.cookie-banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  background: var(--bg-white);
+  border-top: 2px solid var(--navy);
+}
+
+.cookie-inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: var(--space-md) var(--space-lg);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-lg);
+}
+
+.cookie-message {
+  font-size: 0.8125rem;
+  color: var(--text-dark);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.cookie-link {
+  color: var(--teal);
+  text-decoration: underline;
+}
+
+.cookie-button {
+  flex-shrink: 0;
+}
+
+.cookie-fade-enter-active,
+.cookie-fade-leave-active {
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.cookie-fade-enter-from,
+.cookie-fade-leave-to {
+  transform: translateY(100%);
+  opacity: 0;
+}
+
+@media (max-width: 768px) {
+  .cookie-inner {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-md);
+  }
+
+  .cookie-button {
+    width: 100%;
+    text-align: center;
+    justify-content: center;
+  }
+}
+</style>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -63,6 +63,11 @@ const router = createRouter({
       name: 'heimdall',
       component: () => import('../views/HeimdallView.vue'),
     },
+    {
+      path: '/privacy',
+      name: 'privacy',
+      component: () => import('../views/PrivacyView.vue'),
+    },
   ],
 })
 

--- a/src/views/PrivacyView.vue
+++ b/src/views/PrivacyView.vue
@@ -1,0 +1,125 @@
+<script setup lang="ts">
+// Static privacy and cookies statement. No backend, no icons.
+</script>
+
+<template>
+  <!-- Hero Section -->
+  <section class="hero">
+    <div class="container">
+      <div class="hero-content">
+        <span class="stamp stamp-teal">Privacy</span>
+        <h1>Privacy and Cookies</h1>
+        <p class="hero-subtitle">How thedeveco.com handles your information.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Statement -->
+  <section class="statement-section">
+    <div class="container">
+      <div class="statement">
+        <h2>Overview</h2>
+        <p>
+          devEco Consulting LLC operates thedeveco.com. This statement explains what information
+          the site does and does not collect, in plain language. It is current as of 2026-06-26.
+        </p>
+
+        <h2>Information We Collect</h2>
+        <p>
+          The site does not collect or store personal information. There is no account system, no
+          analytics, and no tracking. If you contact devEco through the email or social channels
+          listed on the <router-link to="/contact">Contact</router-link> page, devEco receives only
+          the information you choose to share in that message.
+        </p>
+
+        <h2>Cookies and Local Storage</h2>
+        <p>
+          The site uses only strictly necessary browser storage required for it to function: a
+          single session storage entry that supports in-app navigation. It does not set cookies for
+          advertising, analytics, or tracking. Because only essential storage is used, consent is
+          not legally required, but the site shows a brief notice for transparency. You can clear
+          this storage at any time through your browser settings.
+        </p>
+
+        <h2>Third-Party Services</h2>
+        <p>
+          The site loads the JetBrains Mono typeface from Google Fonts. When your browser requests
+          the font files, Google may receive standard request data such as your IP address, handled
+          under Google's own privacy policy. The site is hosted on GitHub Pages, and as part of
+          serving the site, GitHub may process standard server information such as IP addresses,
+          handled under GitHub's privacy practices. devEco does not control or receive this data.
+        </p>
+
+        <h2>Your Choices</h2>
+        <p>
+          You can dismiss the cookie notice by selecting Got it. You can clear or block browser
+          storage through your browser settings at any time. Because the site does not track you,
+          there is nothing to opt out of.
+        </p>
+
+        <h2>Contact</h2>
+        <p>
+          Questions about this statement can be sent to
+          <a href="mailto:hello@thedeveco.com">hello@thedeveco.com</a>.
+        </p>
+
+        <h2>Changes</h2>
+        <p>
+          devEco may update this statement as the site changes. This version is current as of
+          2026-06-26.
+        </p>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.hero {
+  background: var(--navy);
+  color: white;
+  text-align: center;
+  padding: var(--space-2xl) 0;
+}
+
+.hero-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-md);
+}
+
+.hero h1 {
+  color: white;
+}
+
+.hero-subtitle {
+  font-size: 0.9375rem;
+  color: var(--bg-light);
+  max-width: 600px;
+}
+
+.statement {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.statement h2 {
+  margin-top: var(--space-xl);
+  margin-bottom: var(--space-md);
+}
+
+.statement h2:first-child {
+  margin-top: 0;
+}
+
+.statement p {
+  font-size: 0.875rem;
+  color: var(--text-mid);
+  line-height: 1.7;
+}
+
+.statement a {
+  color: var(--teal);
+  text-decoration: underline;
+}
+</style>


### PR DESCRIPTION
Adds a simple, on-brand cookie consent notice and a /privacy page.
- CookieConsent.vue: fixed bottom notice, first-visit only, dismissal persisted in localStorage (deveco-cookie-consent). Mounted globally in App.vue.
- PrivacyView.vue at /privacy: honest privacy and cookie statement reflecting the current no-tracking state (essential storage only, Google Fonts and GitHub Pages disclosed).
- Privacy link added to the footer.
- CLAUDE.md, README, and CHANGELOG updated. npm run build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012M4sv4G45ZGGGRhBnCHWVJ)_